### PR TITLE
update-copyright-year: permit leading spaces

### DIFF
--- a/bin/update-copyright-year
+++ b/bin/update-copyright-year
@@ -17,10 +17,10 @@ substitute() {
   local -r year="$(git log --date=format:%Y --pretty=format:%ad | sort -r | head -n 1)"
   {
     while IFS= read -r line ; do
-      local pattern='^Copyright [(]c[)] [0-9]{4} (.*)$'
-      if [[ "$line" =~ $pattern ]] && [[ "${BASH_REMATCH[1]}" == "$author" ]] ; then
+      local pattern='^([ ]*Copyright [(]c[)]) [0-9]{4} (.*)$'
+      if [[ "$line" =~ $pattern ]] && [[ "${BASH_REMATCH[2]}" == "$author" ]] ; then
         (( count += 1 ))
-        echo "Copyright (c) $year $author"
+        echo "${BASH_REMATCH[1]} $year $author"
       else
         echo "$line"
       fi


### PR DESCRIPTION
This change is necessary to support WTFPL as its [template][1] is for some reason indented by one space.


[1]: http://www.wtfpl.net/txt/copying/
