### PR TITLE
lint-package-json: validate "license"

### DIFF
--- a/bin/lint-package-json
+++ b/bin/lint-package-json
@@ -47,7 +47,11 @@ assert "!('private' in pkg)"
 
 assert "matches(pkg.description, /.{10}/)"
 
-assert "matches(pkg.license, /./)"
+assert "(function() {
+          var parse = require('spdx-expression-parse');
+          try { parse(pkg.license); } catch (err) { return false; }
+          return true;
+        }())"
 
 assert "isSortedObject(pkg.repository)
         && pkg.repository.type === 'git'

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "remark-lint-no-unused-definitions": "1.x.x",
     "remember-bower": "0.1.x",
     "sanctuary-style": "1.1.x",
+    "spdx-expression-parse": "3.0.x",
     "transcribe": "1.0.x",
     "xyz": "3.0.x"
   },


### PR DESCRIPTION
The question of how to format this value arose in davidchambers/string-format#26.
