### PR TITLE
package.json: specify minimum compatible npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "sanctuary-test": "bin/test",
     "sanctuary-update-copyright-year": "bin/update-copyright-year"
   },
+  "engines": {
+    "npm": ">=3.0.0"
+  },
   "dependencies": {
     "doctest": "0.14.x",
     "eslint": "4.9.x",


### PR DESCRIPTION
This package relies on the flat arrangement of the __node_modules__ directory introduced in [`npm@3.0.0`][1]. By specifying `engines.npm` in __package.json__, a warning message will be displayed if the package is installed using an incompatible version of npm.


[1]: https://github.com/npm/npm/releases/tag/v3.0.0
