### PR TITLE
generate-readme: respect ‘heading-level’ when performing ‘#’ expansion

### DIFF
--- a/bin/generate-readme
+++ b/bin/generate-readme
@@ -38,7 +38,8 @@ insert_version_urls() {
     log(pkg.devDependencies);
   ')"
 
-  local -r pattern1='^(#### <a name=")([^"]*)(".*)$'
+  local hashes='######'
+  local -r pattern1='^('${hashes:0:$heading_level}' <a name=")([^"]*)(".*)$'
   local -r pattern2='^(.+) ([Vv]):([^/]+)/([^# ]+)'  # V => 1.2.3 ; v => v1.2.3
   local -r pattern3='^[0-9]+[.][0-9]+[.][0-9]+$'
   while IFS= read -r line ; do


### PR DESCRIPTION
`####` is currently hard-coded. This pull requests replaces these hard-coded hash signs with an expression, to enable `#` expansion for `heading-level` values other than `4` (the default value).
