### PR TITLE
lint-readme: lint doctests and other code blocks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,10 @@
 {
   "root": true,
-  "extends": ["./node_modules/sanctuary-style/eslint-es3.json"]
+  "extends": ["./node_modules/sanctuary-style/eslint-es3.json"],
+  "overrides": [
+    {
+      "files": ["*.md"],
+      "plugins": ["markdown"]
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ __sanctuary-generate-readme__ when using npm scripts).
     ```json
     {
       "root": true,
-      "extends": ["./node_modules/sanctuary-style/eslint-es3.json"]
+      "extends": ["./node_modules/sanctuary-style/eslint-es3.json"],
+      "overrides": [
+        {
+          "files": ["*.md"],
+          "plugins": ["markdown"]
+        }
+      ]
     }
     ```
 
@@ -183,6 +189,9 @@ Configurable via [variables][] (`repo-owner`, `repo-name`).
 Uses [`remark`↗︎][] to assert that the readme, when built, will not contain any
 undefined link references or unused link definitions.
 
+Uses [`eslint`↗︎][] and [`eslint-plugin-markdown`↗︎][] to assert that the readme,
+when built, will not contain examples which violate the project's style guide.
+
 ### `prepublish`
 
 Runs [`update-copyright-year`][] and [`generate-readme`][], and marks (via
@@ -218,26 +227,27 @@ Assumes that the licence file contains `Copyright (c) <year> <author-name>`.
 Configurable via [variables][] (`author-name`, `license-file`).
 
 
-[`check-required-files`]:   #check-required-files
-[`doctest`]:                #doctest
-[`generate-readme`]:        #generate-readme
-[`lint`]:                   #lint
-[`lint-bower-json`]:        #lint-bower-json
-[`lint-commit-messages`]:   #lint-commit-messages
-[`lint-package-json`]:      #lint-package-json
-[`lint-readme`]:            #lint-readme
-[`prepublish`]:             #prepublish
-[`release`]:                #release
-[`test`]:                   #test
-[`update-copyright-year`]:  #update-copyright-year
-[custom scripts]:           #custom-scripts
-[variables]:                #variables
+[`check-required-files`]:     #check-required-files
+[`doctest`]:                  #doctest
+[`generate-readme`]:          #generate-readme
+[`lint`]:                     #lint
+[`lint-bower-json`]:          #lint-bower-json
+[`lint-commit-messages`]:     #lint-commit-messages
+[`lint-package-json`]:        #lint-package-json
+[`lint-readme`]:              #lint-readme
+[`prepublish`]:               #prepublish
+[`release`]:                  #release
+[`test`]:                     #test
+[`update-copyright-year`]:    #update-copyright-year
+[custom scripts]:             #custom-scripts
+[variables]:                  #variables
 
-[Istanbul↗︎]:                https://istanbul.js.org/
-[Mocha↗︎]:                   https://mochajs.org/
-[`doctest`↗︎]:               https://github.com/davidchambers/doctest
-[`eslint`↗︎]:                https://eslint.org/
-[`remark`↗︎]:                http://remark.js.org/
-[`remember-bower`↗︎]:        https://github.com/davidchambers/remember-bower
-[`transcribe`↗︎]:            https://github.com/plaid/transcribe
-[`xyz`↗︎]:                   https://github.com/davidchambers/xyz
+[Istanbul↗︎]:                  https://istanbul.js.org/
+[Mocha↗︎]:                     https://mochajs.org/
+[`doctest`↗︎]:                 https://github.com/davidchambers/doctest
+[`eslint`↗︎]:                  https://eslint.org/
+[`eslint-plugin-markdown`↗︎]:  https://github.com/eslint/eslint-plugin-markdown
+[`remark`↗︎]:                  http://remark.js.org/
+[`remember-bower`↗︎]:          https://github.com/davidchambers/remember-bower
+[`transcribe`↗︎]:              https://github.com/plaid/transcribe
+[`xyz`↗︎]:                     https://github.com/davidchambers/xyz

--- a/bin/lint-readme
+++ b/bin/lint-readme
@@ -8,10 +8,37 @@ run_custom_script lint-readme "$@"
 
 if test -f README.md ; then
   cp README.md README.md.orig
-  trap 'mv README.md.orig README.md' EXIT
+  trap 'rm -f README.md.temp && mv README.md.orig README.md' EXIT
 else
-  trap 'rm README.md' EXIT
+  trap 'rm -f README.md.temp && rm README.md' EXIT
 fi
+
+rewrite() {
+  local state=
+  local line
+  while IFS='' read -r line ; do
+    local a="${line:0:1}"
+    local b="${line:1:1}"
+    local z="${line: -1}"
+    if [[ $a$b == '> ' ]] ; then
+      printf '\n%s' "${line:2}"
+      state=input
+    elif [[ -n $state && $a$b == '. ' ]] ; then
+      printf '\n%s' "${line:2}"
+    elif [[ $state == input && $a$z == '{}' ]] ; then
+      printf ';\n%s' "($line)"
+      state=output
+    elif [[ $state == input ]] ; then
+      printf ';\n%s' "$line"
+      state=output
+    elif [[ $state == output ]] ; then
+      printf ';\n%s' "$line"
+      state=
+    else
+      printf '\n%s' "$line"
+    fi
+  done
+}
 
 VERSION=0.0.0 run generate-readme
 
@@ -21,3 +48,8 @@ node_modules/.bin/remark \
   --use remark-lint-no-undefined-references \
   --use remark-lint-no-unused-definitions \
   -- README.md
+
+cp README.md README.md.temp
+rewrite <README.md.temp >README.md
+
+node_modules/.bin/eslint -- README.md

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "doctest": "0.14.x",
     "eslint": "4.9.x",
+    "eslint-plugin-markdown": "1.0.0-beta.8",
     "istanbul": "0.4.x",
     "mocha": "5.x.x",
     "remark-cli": "5.x.x",


### PR DESCRIPTION
With these changes, `lint-readme` will assert that code within `` ```javascript `` blocks conforms to the project's style guide.
