### PR TITLE
Acknowledge .mjs files

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -20,7 +20,7 @@ fi
 run check-required-files
 node_modules/.bin/eslint \
   --report-unused-disable-directives \
-  -- "${files[@]}" '*.js' 'test/**/*.js'
+  -- "${files[@]}" '*.{js,mjs}' 'test/**/*.{js,mjs}'
 run lint-package-json
 run lint-bower-json
 run lint-readme


### PR DESCRIPTION
Hi! `sanctuary-lint` assumes that files must end in `js` to be linted. I've added the new `mjs` extension to it.