### PR TITLE
lint-readme: support doctests that are expected to throw

### DIFF
--- a/bin/lint-readme
+++ b/bin/lint-readme
@@ -33,27 +33,22 @@ rewrite() {
       fi
     elif [[ $line == "$closing" ]] ; then
       state=closed
-      [[ $prev == *';' ]] || printf ';'
+      [[ $prev == *';' ]] || [[ -z $prev ]] || printf ';'
     elif [[ ${line:0:2} == '> ' ]] ; then
       line="${line:2}"
       state=input
     elif [[ ${line:0:2} == '. ' ]] ; then
       line="${line:2}"
     elif [[ $state == input ]] ; then
-      if [[ $line == '{'*'}' ]] ; then
+      if [[ ${line:0:2} == '! ' ]] ; then
+        line=
+      elif [[ $line == '{'*'}' ]] ; then
         line="($line)"
       fi
-      # If the line following an input line is empty, there is no output line.
-      # Revert to the "open" state to avoid inserting an unnecessary semicolon.
-      if [[ -z $line ]] ; then
-        state=open
-      else
-        state=output
-      fi
-      [[ $prev == *';' ]] || printf ';'
+      [[ $prev == *';' ]] || [[ -z $prev ]] || printf ';'
     elif [[ $state == output ]] ; then
       state=open
-      [[ $prev == *';' ]] || printf ';'
+      [[ $prev == *';' ]] || [[ -z $prev ]] || printf ';'
     fi
     printf '\n%s' "$line"
     prev="$line"


### PR DESCRIPTION
This pull request enables the use of <https://github.com/davidchambers/doctest#exceptions> by blanking output lines beginning with `! ` when rewriting the readme. These lines are treated specially by doctest, and are not intended to be syntactically valid JavaScript code.
