### PR TITLE
Add 'module-type' option determining how README is linted

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Many variables have default values and are therefore optional.
 | `comment-prefix`              | `.`                   | The character which follows `//` to signify documentation to transcribe.      |
 | `opening-delimiter`           | `` ```javascript ``   | The opening delimiter of doctest blocks in the source files.                  |
 | `closing-delimiter`           | `` ``` ``             | The closing delimiter of doctest blocks in the source files.                  |
+| `module-type`                 | `commonjs`            | The module system doctest should use (`amd`, `commonjs`, or `esm`).           |
 | `version-tag-prefix`          | `v`                   | The prefix of annotated version tags (`version-tag-prefix =` for no prefix).  |
 
 ### Custom scripts
@@ -122,7 +123,7 @@ Runs [`doctest`↗︎][] with suitable `--module`, `--prefix`,
 `--opening-delimiter`, and `--closing-delimiter` values.
 
 Configurable via [variables][] (`source-files`, `comment-prefix`,
-`opening-delimiter`, `closing-delimiter`).
+`opening-delimiter`, `closing-delimiter`, `module-type`).
 
 ### `generate-readme`
 
@@ -190,7 +191,8 @@ undefined link references or unused link definitions.
 Uses [`eslint`↗︎][] and [`eslint-plugin-markdown`↗︎][] to assert that the readme,
 when built, will not contain examples which violate the project's style guide.
 
-Configurable via [variables][] (`opening-delimiter`, `closing-delimiter`).
+Configurable via [variables][] (`opening-delimiter`, `closing-delimiter`
+`module-type`).
 
 ### `prepublish`
 

--- a/bin/doctest
+++ b/bin/doctest
@@ -16,6 +16,11 @@ opening="$(get opening-delimiter)"
 closing="$(get closing-delimiter)"
 module="$(get module-type)"
 
+if [[ "$module" == esm ]] && [[ "$(node_major_version)" -lt 9 ]] ; then
+  echo 'Skipping ESM doctests on Node.js version less than v9.0.0' >&2
+  exit 0
+fi
+
 node_modules/.bin/doctest \
   --module "$module" \
   --prefix "$prefix" \

--- a/bin/doctest
+++ b/bin/doctest
@@ -14,9 +14,10 @@ set -f ; shopt -u nullglob
 prefix="$(get comment-prefix)"
 opening="$(get opening-delimiter)"
 closing="$(get closing-delimiter)"
+module="$(get module-type)"
 
 node_modules/.bin/doctest \
-  --module commonjs \
+  --module "$module" \
   --prefix "$prefix" \
   --opening-delimiter "$opening" \
   --closing-delimiter "$closing" \

--- a/bin/lint-readme
+++ b/bin/lint-readme
@@ -15,6 +15,7 @@ fi
 
 opening="$(get opening-delimiter)"
 closing="$(get closing-delimiter)"
+module="$(get module-type)"
 
 # https://github.com/davidchambers/doctest/blob/0.16.0/lib/doctest.js#L173-L209
 # displays the algorithm upon which this function is based. Differences:
@@ -68,4 +69,12 @@ node_modules/.bin/remark \
 cp README.md README.md.temp
 rewrite <README.md.temp >README.md
 
-node_modules/.bin/eslint -- README.md
+if [[ $module == esm ]] ; then
+  source=module
+else
+  source=script
+fi
+
+node_modules/.bin/eslint \
+  --parser-options "sourceType:$source" \
+  -- README.md

--- a/functions
+++ b/functions
@@ -32,6 +32,7 @@ get() {
                             printf '```javascript' ;;
     closing-delimiter)      # shellcheck disable=SC2016
                             printf '```' ;;
+    module-type)            printf 'commonjs' ;;
     version-tag-prefix)     printf 'v' ;;
     *)
       echo "'$1' not defined in $config" >&2

--- a/functions
+++ b/functions
@@ -72,3 +72,7 @@ pass() {
 fail() {
   echo $'\x1B[0;31m\xE2\x9C\x98\x1B[0m' "$@"
 }
+
+node_major_version() {
+  node --print process.versions.node | cut -d . -f 1
+}


### PR DESCRIPTION
# Changes

- Update doctest to the latest version
- Expose doctest' new ESM feature through a `module-type` setting that users can add in their `.config`. This option also ensures that code examples are treated as "modules" by the linter.