### PR TITLE
Add support for .mjs files in code coverage reports

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -16,4 +16,6 @@ node_modules/.bin/nyc \
   --statements  0 \
   --reporter    text \
   --reporter    html \
+  --extension   .js \
+  --extension   .mjs \
   -- node_modules/.bin/mocha


### PR DESCRIPTION
With `--require esm` in `mocha.opts`, it is possible to create test files that mix `.js` and `.mjs` files. Without this addition, `nyc` ignores the `.mjs` files when reporting code coverage.