### PR TITLE
lint-readme: permit unescaped use of […] and [...]

### DIFF
--- a/bin/lint-readme
+++ b/bin/lint-readme
@@ -61,7 +61,7 @@ VERSION=0.0.0 run generate-readme
 node_modules/.bin/remark \
   --frail \
   --no-stdout \
-  --use remark-lint-no-undefined-references \
+  --use remark-lint-no-undefined-references='allow:["…","..."]' \
   --use remark-lint-no-unused-definitions \
   -- README.md
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "mocha": "5.x.x",
     "nyc": "13.x.x",
     "remark-cli": "6.x.x",
-    "remark-lint-no-undefined-references": "1.x.x",
+    "remark-lint-no-undefined-references": "1.1.x",
     "remark-lint-no-unused-definitions": "1.x.x",
     "remember-bower": "0.1.x",
     "sanctuary-style": "3.0.x",


### PR DESCRIPTION
See remarkjs/remark-lint#210
