### PR TITLE
circle: install ShellCheck directly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,16 +11,7 @@ jobs:
     parallelism: 1
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - cabal-cache-{{ checksum ".circleci/config.yml" }}
-      - run: sudo apt-get install cabal-install
-      - run: cabal update
-      - run: cabal sandbox init
-      - run: cabal install shellcheck-0.4.7
-      - save_cache:
-          key: cabal-cache-{{ checksum ".circleci/config.yml" }}
-          paths:
-            - .cabal-sandbox
+      - run: sudo apt-get update
+      - run: sudo apt-get install shellcheck
       - run: npm install
-      - run: PATH="$(pwd)/.cabal-sandbox/bin:$PATH" npm test
+      - run: npm test


### PR DESCRIPTION
`cabal update` is [failing][1] for #26. <https://github.com/koalaman/shellcheck/wiki/CircleCI> shows a simpler way to install ShellCheck, which is likely to be more reliable. Let's simplify. :)


[1]: https://circleci.com/gh/sanctuary-js/sanctuary-scripts/219
