### PR TITLE
circle: use shellcheck orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,31 @@
 version: 2.1
 
+orbs:
+  node: circleci/node@4.3.0
+  shellcheck: circleci/shellcheck@2.2.4
+
 jobs:
-  build:
-    docker:
-      - image: circleci/node:12
-        environment:
-          NPM_CONFIG_COLOR: false
-    parallelism: 1
+  test:
+    executor:
+      name: node/default
+      tag: <<parameters.version>>
+    parameters:
+      version:
+        type: string
     steps:
       - checkout
-      - run: sudo apt-get update
-      - run: sudo apt-get install shellcheck
+      - shellcheck/install
       - run: npm install
       - run: npm test
+
+workflows:
+  test:
+    jobs:
+      - test:
+          version: 10.14.2
+      - test:
+          version: 12.0.0
+      - test:
+          version: 14.0.0
+      - test:
+          version: 16.0.0


### PR DESCRIPTION
I noticed that `apt-get install shellcheck` is giving us quite an old version. This pull request gives us a newer [version][1].


[1]: https://github.com/CircleCI-Public/shellcheck-orb/blob/v2.2.4/src/commands/install.yml#L7
