### PR TITLE
generate-readme: use new `readme-source-files` variable

### DIFF
--- a/.config
+++ b/.config
@@ -1,3 +1,4 @@
 repo-owner = sanctuary-js
 repo-name = sanctuary-scripts
 contributing-file = .github/CONTRIBUTING.md
+readme-source-files =

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Many variables have default values and are therefore optional.
 | `contributing-file`           | `CONTRIBUTING.md`     | The name of the CONTRIBUTING file.                                            |
 | `license-file`                | `LICENSE`             | The name of the licence file.                                                 |
 | `source-files`                | `index.js`            | Space-separated list of filenames. Globbing is supported.                     |
+| `readme-source-files`         | `index.js`            | Space-separated list of filenames. Globbing is supported.                     |
 | `heading-level`               | `4`                   | The `<h[1-6]>` level of headings transcribed from `heading-prefix` comments.  |
 | `heading-prefix`              | `#`                   | The character which follows `//` to signify a heading to transcribe.          |
 | `comment-prefix`              | `.`                   | The character which follows `//` to signify documentation to transcribe.      |
@@ -141,8 +142,9 @@ produce a Markdown readme:
 that the dependency's version be specified exactly (`"1.2.3"` rather
 than `"1.2.x"`, for example).
 
-Configurable via [variables][] (`repo-owner`, `repo-name`, `source-files`,
-`heading-level`, `heading-prefix`, `comment-prefix`, `version-tag-prefix`).
+Configurable via [variables][] (`repo-owner`, `repo-name`,
+`readme-source-files`, `heading-level`, `heading-prefix`, `comment-prefix`,
+`version-tag-prefix`).
 
 ### `lint`
 

--- a/bin/generate-readme
+++ b/bin/generate-readme
@@ -8,7 +8,7 @@ run_custom_script generate-readme "$@"
 
 set +f ; shopt -s nullglob
 # shellcheck disable=SC2207
-files=($(get source-files))
+files=($(get readme-source-files))
 set -f ; shopt -u nullglob
 
 (( ${#files[@]} == 0 )) && exit 0

--- a/functions
+++ b/functions
@@ -26,6 +26,7 @@ get() {
     contributing-file)      printf 'CONTRIBUTING.md' ;;
     license-file)           printf 'LICENSE' ;;
     source-files)           printf 'index.js' ;;
+    readme-source-files)    printf 'index.js' ;;
     heading-level)          printf '4' ;;
     heading-prefix)         printf '#' ;;
     comment-prefix)         printf '.' ;;


### PR DESCRIPTION
The `source-files` variable serves too many roles.

A project may have one or more scripts in addition to the source files from which the readme is generated. These scripts are not included in `source-files`, as they should not be processed by Transcribe, but this means they are not linted by default.

The workaround is to create a custom `lint` script such as the following:

```bash
#!/usr/bin/env bash
set -euf -o pipefail

node_modules/.bin/sanctuary-lint "$@"

node_modules/.bin/eslint \
  --report-unused-disable-directives \
  -- scripts/bundle
```

This pull request separates `source-files` into `source-files` and `readme-source-files`. The following change would render the custom `lint` script redundant:

```diff
 repo-owner = sanctuary-js
 repo-name = sanctuary
 contributing-file = .github/CONTRIBUTING.md
+source-files = index.js scripts/bundle
```
