### PR TITLE
lint-commit-messages: count multibyte characters intelligently

### DIFF
--- a/bin/lint-commit-messages
+++ b/bin/lint-commit-messages
@@ -31,8 +31,9 @@ branch_name() {
 # Find all commits to be merged, and assert that none of them exceeds
 # the character limit. Ignore merge commits to accommodate Travis, which
 # makes a merge commit (with a long message) in order to test the result
-# of merging the pull request.
-if git log --no-merges --format=%s "$default_branch.." | grep ".\\{$max_length\\}." ; then
+# of merging the pull request. Specify LC_CTYPE=C.UTF-8, if available,
+# so grep will count multibyte characters intelligently.
+if git log --no-merges --format=%s "$default_branch.." | LC_CTYPE="$(locale -a | grep '^C[.]UTF-8$' || echo "$LC_CTYPE")" grep ".\\{$max_length\\}." ; then
   fail "At least one commit summary exceeds $max_length-character limit"
   exit 1
 fi


### PR DESCRIPTION
If `LC_CTYPE` is not set appropriately, `grep` miscounts the characters in this commit message:

```console
$ echo 'provide custom ‘inspect’ behaviour in Node without using ‘require’' | LC_CTYPE=POSIX grep "^.\\{74\\}$"
provide custom ‘inspect’ behaviour in Node without using ‘require’
```

The commit message actually contains 66 rather than 74 characters, if the multibyte characters are counted intelligently:

```console
$ echo 'provide custom ‘inspect’ behaviour in Node without using ‘require’' | LC_CTYPE="$(locale -a | grep '^C[.]UTF-8$' || echo "$LC_CTYPE")" grep "^.\\{66\\}$"
provide custom ‘inspect’ behaviour in Node without using ‘require’
```

The fix provided in this pull request is to specify `LC_CTYPE=C.UTF-8` if `C.UTF-8` is one of the available locales.

Another solution would be to encourage users to set `LC_CTYPE` locally and on their continuous integration servers, but I think we should make an effort to count characters correctly no matter how the system is configured.
