### PR TITLE
enable ‘globstar’

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Many variables have default values and are therefore optional.
 | `author-name`                 | `Sanctuary`           | The name of the individual or group to whom copyright should be attributed.   |
 | `contributing-file`           | `CONTRIBUTING.md`     | The name of the CONTRIBUTING file.                                            |
 | `license-file`                | `LICENSE`             | The name of the licence file.                                                 |
-| `source-files`                | `index.js`            | Space-separated list of filenames. Globbing is supported.                     |
-| `readme-source-files`         | `index.js`            | Space-separated list of filenames. Globbing is supported.                     |
+| `source-files`                | `index.js`            | Space-separated list of filenames. Globbing is supported (with `globstar`).   |
+| `readme-source-files`         | `index.js`            | Space-separated list of filenames. Globbing is supported (with `globstar`).   |
 | `heading-level`               | `4`                   | The `<h[1-6]>` level of headings transcribed from `heading-prefix` comments.  |
 | `heading-prefix`              | `#`                   | The character which follows `//` to signify a heading to transcribe.          |
 | `comment-prefix`              | `.`                   | The character which follows `//` to signify documentation to transcribe.      |

--- a/bin/doctest
+++ b/bin/doctest
@@ -6,10 +6,10 @@ source "${BASH_SOURCE%/*}/../sanctuary-scripts/functions"
 
 run_custom_script doctest "$@"
 
-set +f ; shopt -s nullglob
+set +f ; shopt -s globstar nullglob
 # shellcheck disable=SC2207
 files=($(get source-files))
-set -f ; shopt -u nullglob
+set -f ; shopt -u globstar nullglob
 
 prefix="$(get comment-prefix)"
 opening="$(get opening-delimiter)"

--- a/bin/generate-readme
+++ b/bin/generate-readme
@@ -6,10 +6,10 @@ source "${BASH_SOURCE%/*}/../sanctuary-scripts/functions"
 
 run_custom_script generate-readme "$@"
 
-set +f ; shopt -s nullglob
+set +f ; shopt -s globstar nullglob
 # shellcheck disable=SC2207
 files=($(get readme-source-files))
-set -f ; shopt -u nullglob
+set -f ; shopt -u globstar nullglob
 
 (( ${#files[@]} == 0 )) && exit 0
 

--- a/bin/lint
+++ b/bin/lint
@@ -6,10 +6,10 @@ source "${BASH_SOURCE%/*}/../sanctuary-scripts/functions"
 
 run_custom_script lint "$@"
 
-set +f ; shopt -s nullglob
+set +f ; shopt -s globstar nullglob
 # shellcheck disable=SC2207
 files=($(get source-files))
-set -f ; shopt -u nullglob
+set -f ; shopt -u globstar nullglob
 
 if [[ "${PUBLISHING-false}" == true ]] ; then
   echo 'Running "npm install" to negate "npm prune"'


### PR DESCRIPTION
This configuration does not currently work as one might expect:

```
source-files = src/**/*.js
```

When the `globstar` shell option is not enabled, `**` is not recursive; one must provide multiple patterns if the source files are not all siblings. In addition to being inelegant, `src/*.js src/**/*.js` is fragile as it hard-codes the maximum depth.

This pull request enables the `globstar` shell option before expanding `source-files` and `readme-source-files`. :)

The following script can be run once to demonstrate the existing behaviour and once to demonstrate the new behaviour:

```bash
#!/usr/bin/env bash
set -euf -o pipefail

cd "$(mktemp -d)"
pwd

tee package.json <<EOF
{
  "name": "repo-name",
  "version": "0.0.0",
  "devDependencies": {
    "sanctuary-scripts": "sanctuary-js/sanctuary-scripts#$1"
  },
  "scripts": {
    "doctest": "sanctuary-doctest",
    "lint": "sanctuary-lint",
    "release": "sanctuary-release",
    "test": "npm run lint && sanctuary-test && npm run doctest"
  }
}
EOF

tee .config <<EOF
repo-owner = repo-owner
repo-name = repo-name
source-files = foo/**/*.js
EOF

tee .eslintrc.json <<EOF
{
  "root": true,
  "extends": ["./node_modules/sanctuary-style/eslint-es6.json"]
}
EOF

touch CONTRIBUTING.md
touch LICENSE
touch .gitignore
touch .npmrc

mkdir -p foo/bar/baz
echo '"use strict"' >foo/index.js
echo '"use strict"' >foo/bar/index.js
echo '"use strict"' >foo/bar/baz/index.js

npm install
npm run lint
```

When run against `master`, only errors in __foo/bar/index.js__ are reported. When run against `davidchambers/globstar`, errors in all three source files are reported.
