### PR TITLE
doctest: remove check for old Node.js versions

### DIFF
--- a/bin/doctest
+++ b/bin/doctest
@@ -16,11 +16,6 @@ opening="$(get opening-delimiter)"
 closing="$(get closing-delimiter)"
 module="$(get module-type)"
 
-if [[ "$module" == esm ]] && [[ "$(node_major_version)" -lt 9 ]] ; then
-  echo 'Skipping ESM doctests on Node.js version less than v9.0.0' >&2
-  exit 0
-fi
-
 node_modules/.bin/doctest \
   --module "$module" \
   --prefix "$prefix" \

--- a/functions
+++ b/functions
@@ -74,7 +74,3 @@ pass() {
 fail() {
   echo $'\x1B[0;31m\xE2\x9C\x98\x1B[0m' "$@"
 }
-
-node_major_version() {
-  node --print process.versions.node | cut -d . -f 1
-}


### PR DESCRIPTION
This reverts commit 39dcbe399455a5d79fe82298eccf7039fd49c162.

The removal of the check is not a breaking change as it does not affect supported Node.js versions:

```console
$ jq .engines.node package.json
">=12.22.0"
```
