### PR TITLE
change default value of `module-type` from `commonjs` to `esm`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
   "root": true,
   "extends": ["./node_modules/sanctuary-style/eslint-es6.json"],
-  "env": {"node": true}
+  "parserOptions": {"sourceType": "module"}
 }

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Many variables have default values and are therefore optional.
 | `comment-prefix`              | `.`                   | The character which follows `//` to signify documentation to transcribe.      |
 | `opening-delimiter`           | `` ```javascript ``   | The opening delimiter of doctest blocks in the source files.                  |
 | `closing-delimiter`           | `` ``` ``             | The closing delimiter of doctest blocks in the source files.                  |
-| `module-type`                 | `commonjs`            | The module system doctest should use (`amd`, `commonjs`, or `esm`).           |
+| `module-type`                 | `esm`                 | The module system doctest should use (`amd`, `commonjs`, or `esm`).           |
 | `version-tag-prefix`          | `v`                   | The prefix of annotated version tags (`version-tag-prefix =` for no prefix).  |
 
 ### Custom scripts

--- a/functions
+++ b/functions
@@ -34,7 +34,7 @@ get() {
                             printf '```javascript' ;;
     closing-delimiter)      # shellcheck disable=SC2016
                             printf '```' ;;
-    module-type)            printf 'commonjs' ;;
+    module-type)            printf 'esm' ;;
     version-tag-prefix)     printf 'v' ;;
     *)
       echo "'$1' not defined in $config" >&2

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 //# identity :: a -> a
 //.
 //. Returns its argument.
@@ -8,6 +6,4 @@
 //. > identity ([1, 2, 3])
 //. [1, 2, 3]
 //. ```
-const identity = x => x;
-
-module.exports = identity;
+export const identity = x => x;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "git://github.com/sanctuary-js/sanctuary-scripts.git"
   },
+  "type": "module",
   "files": [
     "/bin/",
     "/LICENSE",

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,6 @@
-'use strict';
+import assert from 'node:assert';
 
-const assert = require ('node:assert');
-
-const identity = require ('..');
+import {identity} from '../index.js';
 
 
 test ('identity (42)', () => {


### PR DESCRIPTION
> [!IMPORTANT]
>
> Add `module-type = commonjs` to __.config__ when upgrading if you currently rely on the old default value.
