### PR TITLE
shellcheck@0.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,15 @@ version: 2.1
 
 orbs:
   node: circleci/node@5.1.0
-  shellcheck: circleci/shellcheck@2.2.4
+  shellcheck: circleci/shellcheck@3.2.0
 
 workflows:
   test:
     jobs:
       - node/test:
           setup:
-            - shellcheck/install
+            - shellcheck/install:
+                version: 0.9.0
             # derive cache key from package.json
             - run: cp package.json package-lock.json
           override-ci-command: rm package-lock.json && npm install && git checkout -- package.json

--- a/bin/check-required-files
+++ b/bin/check-required-files
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-# shellcheck source=functions
-source "${BASH_SOURCE%/*}/../sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
 
 run_custom_script check-required-files "$@"
 

--- a/bin/doctest
+++ b/bin/doctest
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-# shellcheck source=functions
-source "${BASH_SOURCE%/*}/../sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
 
 run_custom_script doctest "$@"
 

--- a/bin/generate-readme
+++ b/bin/generate-readme
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-# shellcheck source=functions
-source "${BASH_SOURCE%/*}/../sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
 
 run_custom_script generate-readme "$@"
 

--- a/bin/lint
+++ b/bin/lint
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-# shellcheck source=functions
-source "${BASH_SOURCE%/*}/../sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
 
 run_custom_script lint "$@"
 

--- a/bin/lint-commit-messages
+++ b/bin/lint-commit-messages
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-# shellcheck source=functions
-source "${BASH_SOURCE%/*}/../sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
 
 run_custom_script lint-commit-messages "$@"
 

--- a/bin/lint-json
+++ b/bin/lint-json
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-# shellcheck source=functions
-source "${BASH_SOURCE%/*}/../sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
 
 run_custom_script lint-json "$@"
 

--- a/bin/lint-package-json
+++ b/bin/lint-package-json
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-# shellcheck source=functions
-source "${BASH_SOURCE%/*}/../sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
 
 run_custom_script lint-package-json "$@"
 

--- a/bin/prepublish
+++ b/bin/prepublish
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-# shellcheck source=functions
-source "${BASH_SOURCE%/*}/../sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
 
 run_custom_script prepublish "$@"
 

--- a/bin/release
+++ b/bin/release
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-# shellcheck source=functions
-source "${BASH_SOURCE%/*}/../sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
 
 run_custom_script release "$@"
 

--- a/bin/test
+++ b/bin/test
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-# shellcheck source=functions
-source "${BASH_SOURCE%/*}/../sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
 
 run_custom_script test "$@"
 

--- a/bin/update-copyright-year
+++ b/bin/update-copyright-year
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-# shellcheck source=functions
-source "${BASH_SOURCE%/*}/../sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
 
 run_custom_script update-copyright-year "$@"
 

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-# shellcheck source=functions
-source "${BASH_SOURCE%/*}/../sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
 
 set +f
 
@@ -23,15 +22,14 @@ header() {
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-# shellcheck source=functions
-source "\${BASH_SOURCE%/*}/../sanctuary-scripts/functions"
+source "\$(dirname "\$(dirname "\$(realpath "\${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
 
 run_custom_script $1 "\$@"
 EOF
 }
 
 for file in bin/* ; do
-  if [[ "$(head -n 7 "$file" | shasum -a 256)" == "$(header "$(basename "$file")" | shasum -a 256)" ]] ; then
+  if [[ "$(head -n 6 "$file" | shasum -a 256)" == "$(header "$(basename "$file")" | shasum -a 256)" ]] ; then
     pass "$file"
   else
     fail "$file"


### PR DESCRIPTION
> [!IMPORTANT]
>
> These changes are breaking as they introduce a dependency on [`realpath`][1].

I recently discovered a useful ShellCheck feature related to [SC1090][2]:

> ShellCheck v0.7.2+ will strip a single expansion followed by a slash, e.g. `${var}/util.sh` or `$(dirname "${BASH_SOURCE[0]}")/util.sh`, and treat them as `./util.sh`. This allows the use of `source-path` directives or `-P` flags to specify the location.

This pull request upgrades our ShellCheck dependency and changes the way we determine the path to the functions module. Together, these changes obviate the need for the `source` directive wherever the functions module is sourced.


[1]: https://www.gnu.org/software/coreutils/manual/html_node/realpath-invocation.html
[2]: https://www.shellcheck.net/wiki/SC1090
