### PR TITLE
remove symlink

### DIFF
--- a/bin/check-required-files
+++ b/bin/check-required-files
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/functions"
 
 run_custom_script check-required-files "$@"
 

--- a/bin/doctest
+++ b/bin/doctest
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/functions"
 
 run_custom_script doctest "$@"
 

--- a/bin/generate-readme
+++ b/bin/generate-readme
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/functions"
 
 run_custom_script generate-readme "$@"
 

--- a/bin/lint
+++ b/bin/lint
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/functions"
 
 run_custom_script lint "$@"
 

--- a/bin/lint-commit-messages
+++ b/bin/lint-commit-messages
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/functions"
 
 run_custom_script lint-commit-messages "$@"
 

--- a/bin/lint-json
+++ b/bin/lint-json
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/functions"
 
 run_custom_script lint-json "$@"
 

--- a/bin/lint-package-json
+++ b/bin/lint-package-json
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/functions"
 
 run_custom_script lint-package-json "$@"
 

--- a/bin/prepublish
+++ b/bin/prepublish
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/functions"
 
 run_custom_script prepublish "$@"
 

--- a/bin/release
+++ b/bin/release
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/functions"
 
 run_custom_script release "$@"
 

--- a/bin/test
+++ b/bin/test
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/functions"
 
 run_custom_script test "$@"
 

--- a/bin/update-copyright-year
+++ b/bin/update-copyright-year
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/functions"
 
 run_custom_script update-copyright-year "$@"
 

--- a/sanctuary-scripts/functions
+++ b/sanctuary-scripts/functions
@@ -1,1 +1,0 @@
-../functions

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
+source "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}")")")/functions"
 
 set +f
 
@@ -22,7 +22,7 @@ header() {
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-source "\$(dirname "\$(dirname "\$(realpath "\${BASH_SOURCE[0]}")")")/sanctuary-scripts/functions"
+source "\$(dirname "\$(dirname "\$(realpath "\${BASH_SOURCE[0]}")")")/functions"
 
 run_custom_script $1 "\$@"
 EOF


### PR DESCRIPTION
In #61 we switched to a more principled method of determining the project root. This made the symlink redundant.

The symlink's original purpose was to allow scripts to be used internally. I needed to `source` the functions module, which required determining its location. My original solution was to determine the path as if sanctuary-scripts had been installed via npm, and to artificially recreate this path for internal use.

I introduced a regression in #61 by depending on the symlink, which is not included in the npm tarball.

This pull request removes the redundant symlink and updates the paths to the functions module.
