### PR TITLE
replace `mocha` and `nyc` with `oletus` and `c8`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-/.nyc_output/
 /coverage/
 /node_modules/

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Many variables have default values and are therefore optional.
 | `license-file`                | `LICENSE`             | The name of the licence file.                                                 |
 | `source-files`                | `index.js`            | Space-separated list of filenames. Globbing is supported (with `globstar`).   |
 | `readme-source-files`         | `index.js`            | Space-separated list of filenames. Globbing is supported (with `globstar`).   |
+| `test-files`                  | `test/**/*.js`        | Space-separated list of filenames. Globbing is supported (with `globstar`).   |
 | `heading-level`               | `4`                   | The `<h[1-6]>` level of headings transcribed from `heading-prefix` comments.  |
 | `heading-prefix`              | `#`                   | The character which follows `//` to signify a heading to transcribe.          |
 | `comment-prefix`              | `.`                   | The character which follows `//` to signify documentation to transcribe.      |
@@ -153,8 +154,8 @@ Runs the following linters:
   - [`lint-package-json`][]
   - [`lint-commit-messages`][]
 
-Configurable via [variables][] (`source-files` and those respected by the
-aforementioned linters).
+Configurable via [variables][] (`source-files`, `test-files`, and those
+respected by the aforementioned linters).
 
 ### `lint-commit-messages`
 
@@ -197,11 +198,10 @@ Configurable via [variables][] (`repo-owner`, `repo-name`, `default-branch`,
 
 ### `test`
 
-Runs the project's [Mocha↗︎][] test suite via [Istanbul↗︎][] and asserts that the
-test suite satisfies the project's coverage requirements.
+Runs [`oletus`↗︎][] via [`c8`↗︎][] to run the project's test suite and assert
+that it satisfies the project's coverage requirements.
 
-Configurable via [variables][] (`min-branch-coverage`) and the `mocha` field of
-__package.json__.
+Configurable via [variables][] (`min-branch-coverage`, `test-files`).
 
 ### `update-copyright-year`
 
@@ -226,9 +226,9 @@ Configurable via [variables][] (`author-name`, `license-file`).
 [custom scripts]:             #custom-scripts
 [variables]:                  #variables
 
-[Istanbul↗︎]:                  https://istanbul.js.org/
-[Mocha↗︎]:                     https://mochajs.org/
+[`c8`↗︎]:                      https://github.com/bcoe/c8
 [`doctest`↗︎]:                 https://github.com/davidchambers/doctest
 [`eslint`↗︎]:                  https://eslint.org/
+[`oletus`↗︎]:                  https://github.com/bearror/oletus
 [`transcribe`↗︎]:              https://github.com/plaid/transcribe
 [`xyz`↗︎]:                     https://github.com/davidchambers/xyz

--- a/bin/lint
+++ b/bin/lint
@@ -7,7 +7,9 @@ run_custom_script lint "$@"
 
 set +f ; shopt -s globstar nullglob
 # shellcheck disable=SC2207
-files=($(get source-files))
+source_files=($(get source-files))
+# shellcheck disable=SC2207
+test_files=($(get test-files))
 set -f ; shopt -u globstar nullglob
 
 if [[ "${PUBLISHING-false}" == true ]] ; then
@@ -20,6 +22,6 @@ run check-required-files
 node_modules/.bin/eslint \
   --no-error-on-unmatched-pattern \
   --report-unused-disable-directives \
-  -- "${files[@]}" '*.{js,mjs}' 'test/**/*.{js,mjs}'
+  -- "${source_files[@]}" '*.{js,mjs}' "${test_files[@]}"
 run lint-package-json
 run lint-commit-messages

--- a/bin/test
+++ b/bin/test
@@ -7,14 +7,21 @@ run_custom_script test "$@"
 
 branches="$(get min-branch-coverage)"
 
-node_modules/.bin/nyc \
-  --check-coverage \
-  --branches    "$branches" \
-  --functions   0 \
-  --lines       0 \
-  --statements  0 \
-  --reporter    text \
-  --reporter    html \
-  --extension   .js \
-  --extension   .mjs \
-  -- node_modules/.bin/mocha
+set +f ; shopt -s globstar nullglob
+# shellcheck disable=SC2207
+source_files=($(get source-files))
+# shellcheck disable=SC2207
+test_files=($(get test-files))
+set -f ; shopt -u globstar nullglob
+
+args=(
+  --check-coverage
+  --branches    "$branches"
+  --functions   0
+  --lines       0
+  --statements  0
+)
+for name in "${source_files[@]}" ; do
+  args+=(--include "$name")
+done
+node_modules/.bin/c8 "${args[@]}" -- node_modules/.bin/oletus -- "${test_files[@]}"

--- a/functions
+++ b/functions
@@ -27,6 +27,7 @@ get() {
     license-file)           printf 'LICENSE' ;;
     source-files)           printf 'index.js' ;;
     readme-source-files)    printf 'index.js' ;;
+    test-files)             printf 'test/**/*.js' ;;
     heading-level)          printf '4' ;;
     heading-prefix)         printf '#' ;;
     comment-prefix)         printf '.' ;;

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "npm": ">=3.0.0"
   },
   "dependencies": {
+    "c8": "8.0.x",
     "doctest": "0.21.x",
     "eslint": "8.55.x",
-    "mocha": "8.x.x",
-    "nyc": "15.x.x",
+    "oletus": "4.0.x",
     "sanctuary-style": "7.0.x",
     "spdx-expression-parse": "3.0.x",
     "transcribe": "1.1.2",
@@ -48,8 +48,5 @@
     "lint": "bin/lint",
     "release": "bin/release",
     "test": "npm run lint && bin/test && npm run doctest"
-  },
-  "mocha": {
-    "ui": "tdd"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,7 @@
 import assert from 'node:assert';
 
+import test from 'oletus';
+
 import {identity} from '../index.js';
 
 


### PR DESCRIPTION
This pull request removes our `mocha` and `nyc` dependencies in favour of [`oletus`][1] and [`c8`][2].

This pull request also introduces the `test-files` variable, which `lint` and `test` now use.


[1]: https://github.com/bearror/oletus
[2]: https://github.com/bcoe/c8
