### PR TITLE
simplify `scripts` checks in `lint-package-json`

### DIFF
--- a/bin/lint-package-json
+++ b/bin/lint-package-json
@@ -57,10 +57,10 @@ assert "isSortedObject(pkg.repository)
         && pkg.repository.url === 'git://github.com/$owner/$name.git'"
 
 assert "isSortedObject(pkg.scripts)
-        && matches(pkg.scripts.doctest, /^(bin[/]|sanctuary-)doctest$/)
-        && matches(pkg.scripts.lint,    /^(bin[/]|sanctuary-)lint$/)
-        && matches(pkg.scripts.release, /^(bin[/]|sanctuary-)release$/)
-        && matches(pkg.scripts.test,    /^npm run lint && (bin[/]|sanctuary-)test && npm run doctest$/)"
+        && pkg.scripts.doctest === 'sanctuary-doctest'
+        && pkg.scripts.lint === 'sanctuary-lint'
+        && pkg.scripts.release === 'sanctuary-release'
+        && pkg.scripts.test === 'npm run lint && sanctuary-test && npm run doctest'"
 
 assert "isSortedObject(pkg.dependencies)"
 


### PR DESCRIPTION
`lint-package-json` is primarily useful when setting up a project, reminding us about important fields and performing some basic validation of their values. It is less useful in established projects such as this one. By eschewing `lint-package-json` internally we can simplify the `script` checks and their corresponding output.
