### PR TITLE
revert to naive `license` field validation in `lint-package-json`

### DIFF
--- a/bin/lint-package-json
+++ b/bin/lint-package-json
@@ -46,11 +46,7 @@ assert "!('private' in pkg)"
 
 assert "matches(pkg.description, /.{10}/)"
 
-assert "(function() {
-          var parse = require('spdx-expression-parse');
-          try { parse(pkg.license); } catch (err) { return false; }
-          return true;
-        }())"
+assert "matches(pkg.license, /./)"
 
 assert "isSortedObject(pkg.repository)
         && pkg.repository.type === 'git'

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "eslint": "8.55.x",
     "oletus": "4.0.x",
     "sanctuary-style": "7.0.x",
-    "spdx-expression-parse": "3.0.x",
     "transcribe": "1.1.2",
     "xyz": "4.0.x"
   },


### PR DESCRIPTION
This pull request reverts #8.

I now believe that the value provided by `license` field validation does not justify the maintenance burden of a dependency (or the complexity of our own validation code). We get 99% of the value by simply checking that the field is present. Getting the value right is not difficult. Furthermore, the cost of making a mistake is very low.
